### PR TITLE
Map search modal fixes and disabling public leaderboard prefetch

### DIFF
--- a/src/components/PageComponents/ProfilePage/InfluenceList/InfluenceElement.tsx
+++ b/src/components/PageComponents/ProfilePage/InfluenceList/InfluenceElement.tsx
@@ -202,7 +202,8 @@ const AddButton: FC<{
           closeForm={() => setModalOpen(false)}
           onSubmit={onSubmit}
           loading={isPending}
-          suggestionUserId={influenceData.user.id}
+          suggestedUsername={influenceData.user.username}
+          suggestedUserPreviousNames={influenceData.user.previous_usernames}
           mapLimit={LIMIT - (influenceData.beatmaps?.length || 0)}
         />
       </Modal>

--- a/src/components/PageComponents/ProfilePage/MapperDetails/AddUserButton/index.tsx
+++ b/src/components/PageComponents/ProfilePage/MapperDetails/AddUserButton/index.tsx
@@ -71,7 +71,7 @@ const AddUserButton: FC<Props> = ({
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       const body: AddInfluenceRequest = {
-        userId: userId,
+        user_id: userId,
         influence_type: convertFromInfluence(type),
         description,
       };

--- a/src/components/PageComponents/ProfilePage/MapperDetails/FeaturedMaps/index.tsx
+++ b/src/components/PageComponents/ProfilePage/MapperDetails/FeaturedMaps/index.tsx
@@ -67,7 +67,8 @@ const AddButton: FC<{ userId?: string | number }> = ({ userId }) => {
           closeForm={() => setModalOpen(false)}
           onSubmit={onSubmit}
           loading={isPending}
-          suggestionUserId={userId}
+          suggestedUsername={userBio?.username}
+          suggestedUserPreviousNames={userBio?.previous_usernames || []}
           mapLimit={5 - (userBio?.beatmaps?.length || 0)}
         />
       </Modal>

--- a/src/components/SharedComponents/BaseProfileCard/index.tsx
+++ b/src/components/SharedComponents/BaseProfileCard/index.tsx
@@ -14,10 +14,14 @@ import styles from './style.module.scss';
 type Props = {
   className?: string;
   userData?: UserSmall;
-  forceLoading?: boolean;
+  prefetch?: boolean;
 };
 
-const BaseProfileCard: FC<Props> = ({ className = '', userData }) => {
+const BaseProfileCard: FC<Props> = ({
+  className = '',
+  userData,
+  prefetch = true,
+}) => {
   const queryClient = useQueryClient();
 
   const tooltipProps = useGlobalTooltip((state) => state.tooltipProps);
@@ -55,7 +59,7 @@ const BaseProfileCard: FC<Props> = ({ className = '', userData }) => {
     <ConditionalLink
       disabled={!userData || !currentUser}
       href={`/profile/${userData.id}`}
-      onMouseEnter={prefetchUserBio}
+      onMouseEnter={prefetch ? () => prefetchUserBio() : undefined}
       onClick={
         !currentUser
           ? () => {

--- a/src/components/SharedComponents/BaseProfileCard/index.tsx
+++ b/src/components/SharedComponents/BaseProfileCard/index.tsx
@@ -14,7 +14,6 @@ import styles from './style.module.scss';
 type Props = {
   className?: string;
   userData?: UserSmall;
-  prefetch?: boolean;
 };
 
 const BaseProfileCard: FC<Props> = ({ className = '', userData }) => {

--- a/src/components/SharedComponents/BaseProfileCard/index.tsx
+++ b/src/components/SharedComponents/BaseProfileCard/index.tsx
@@ -17,11 +17,7 @@ type Props = {
   prefetch?: boolean;
 };
 
-const BaseProfileCard: FC<Props> = ({
-  className = '',
-  userData,
-  prefetch = true,
-}) => {
+const BaseProfileCard: FC<Props> = ({ className = '', userData }) => {
   const queryClient = useQueryClient();
 
   const tooltipProps = useGlobalTooltip((state) => state.tooltipProps);
@@ -59,7 +55,7 @@ const BaseProfileCard: FC<Props> = ({
     <ConditionalLink
       disabled={!userData || !currentUser}
       href={`/profile/${userData.id}`}
-      onMouseEnter={prefetch ? () => prefetchUserBio() : undefined}
+      onMouseEnter={currentUser ? () => prefetchUserBio() : undefined}
       onClick={
         !currentUser
           ? () => {

--- a/src/components/SharedComponents/Leaderboard/index.tsx
+++ b/src/components/SharedComponents/Leaderboard/index.tsx
@@ -72,7 +72,7 @@ const Leaderboard: FC<{ className?: string }> = ({ className }) => {
         >
           {cachedLeaderboards?.map((item) => (
             <div key={item.user.id} className={styles.row}>
-              <BaseProfileCard userData={item.user} />
+              <BaseProfileCard userData={item.user} prefetch={false} />
               <div className={styles.number}>
                 <span>{item.count}</span>
                 <span>{`Mention${item.count !== 1 ? 's' : ''}`}</span>
@@ -97,7 +97,7 @@ const MockList = () => {
   return Array.from({ length: 5 }).map((_, index) => (
     // biome-ignore lint/suspicious/noArrayIndexKey: <mock list>
     <div key={index} className={styles.row}>
-      <BaseProfileCard />
+      <BaseProfileCard prefetch={false} />
       <div className={styles.number}>
         <span>..</span>
         <span>...</span>

--- a/src/components/SharedComponents/Leaderboard/index.tsx
+++ b/src/components/SharedComponents/Leaderboard/index.tsx
@@ -72,7 +72,7 @@ const Leaderboard: FC<{ className?: string }> = ({ className }) => {
         >
           {cachedLeaderboards?.map((item) => (
             <div key={item.user.id} className={styles.row}>
-              <BaseProfileCard userData={item.user} prefetch={false} />
+              <BaseProfileCard userData={item.user} />
               <div className={styles.number}>
                 <span>{item.count}</span>
                 <span>{`Mention${item.count !== 1 ? 's' : ''}`}</span>
@@ -97,7 +97,7 @@ const MockList = () => {
   return Array.from({ length: 5 }).map((_, index) => (
     // biome-ignore lint/suspicious/noArrayIndexKey: <mock list>
     <div key={index} className={styles.row}>
-      <BaseProfileCard prefetch={false} />
+      <BaseProfileCard />
       <div className={styles.number}>
         <span>..</span>
         <span>...</span>

--- a/src/components/SharedComponents/MapCard/index.tsx
+++ b/src/components/SharedComponents/MapCard/index.tsx
@@ -137,10 +137,12 @@ export const ModeIcon = ({
   mode,
   color,
   onMouseEnter,
+  onMouseLeave,
 }: {
   mode?: string;
   color?: string;
   onMouseEnter?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
+  onMouseLeave?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
 }) => {
   let Component = OsuIcon;
   switch (mode) {
@@ -159,6 +161,10 @@ export const ModeIcon = ({
   }
 
   return (
-    <Component color={color || 'var(--white)'} onMouseEnter={onMouseEnter} />
+    <Component
+      color={color || 'var(--white)'}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    />
   );
 };

--- a/src/components/SharedComponents/MapSearch/index.tsx
+++ b/src/components/SharedComponents/MapSearch/index.tsx
@@ -15,11 +15,17 @@ export const AddMapModalContents: FC<{
   closeForm: () => void;
   onSubmit: (selectedDiffs: number[]) => void;
   mapLimit: number;
-  suggestionUserId?: number | string;
+  suggestedUsername: string | undefined;
+  suggestedUserPreviousNames: string[];
   loading: boolean;
-}> = ({ closeForm, loading, onSubmit, suggestionUserId, mapLimit }) => {
-  const { data: suggestedUser } = useUserBio(suggestionUserId?.toString());
-
+}> = ({
+  closeForm,
+  loading,
+  onSubmit,
+  suggestedUsername,
+  suggestedUserPreviousNames,
+  mapLimit,
+}) => {
   const getFiltersQuery = useFilterStore((state) => state.getQueryString);
 
   const [mapResults, setMapResults] = useState<BeatmapSearch[]>([]);
@@ -28,8 +34,8 @@ export const AddMapModalContents: FC<{
   );
   const [selectedMaps, setSelectedMaps] = useState<number[]>([]);
   const [searchInput, setSearchInput] = useState(
-    suggestedUser
-      ? `creator:${suggestedUser?.username.replaceAll(' ', '_')}`
+    suggestedUsername
+      ? `creator:${suggestedUsername?.replaceAll(' ', '_')}`
       : '',
   );
 
@@ -94,16 +100,15 @@ export const AddMapModalContents: FC<{
               setSearchInput(e.target.value);
               debouncedSearch(e.target.value);
             }}
-            defaultValue={`"${suggestedUser?.username}"`}
             value={searchInput}
             onKeyDown={(e) => {
               if (e.key === 'Enter') e.preventDefault();
             }}
           />
         </label>
-        {!!suggestedUser?.previous_usernames.length && (
+        {!!suggestedUserPreviousNames.length && (
           <span className={styles.previousNames}>
-            Previous usernames: {suggestedUser.previous_usernames.join(', ')}
+            Previous usernames: {suggestedUserPreviousNames.join(', ')}
           </span>
         )}
 

--- a/src/components/SvgComponents/ModeIcons.tsx
+++ b/src/components/SvgComponents/ModeIcons.tsx
@@ -4,11 +4,13 @@ type Props = {
   color?: string;
   className?: string;
   onMouseEnter?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
+  onMouseLeave?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
 };
 export const OsuIcon: FC<Props> = ({
   color = 'var(--textColor)',
   className,
   onMouseEnter,
+  onMouseLeave
 }) => {
   return (
     <svg
@@ -19,6 +21,7 @@ export const OsuIcon: FC<Props> = ({
       viewBox="0 0 24 24"
       fill="none"
       onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <g clipPath="url(#clip0_4188_3248)">
         <g clipPath="url(#clip1_4188_3248)">
@@ -46,6 +49,7 @@ export const TaikoIcon: FC<Props> = ({
   color = 'var(--textColor)',
   className,
   onMouseEnter,
+  onMouseLeave
 }) => {
   return (
     <svg
@@ -56,6 +60,7 @@ export const TaikoIcon: FC<Props> = ({
       viewBox="0 0 24 24"
       fill="none"
       onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <g clipPath="url(#clip0_4188_3249)">
         <g clipPath="url(#clip1_4188_3249)">
@@ -83,6 +88,7 @@ export const ManiaIcon: FC<Props> = ({
   color = 'var(--textColor)',
   className,
   onMouseEnter,
+  onMouseLeave
 }) => {
   return (
     <svg
@@ -93,6 +99,7 @@ export const ManiaIcon: FC<Props> = ({
       viewBox="0 0 24 24"
       fill="none"
       onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <g clipPath="url(#clip0_4188_3251)">
         <g clipPath="url(#clip1_4188_3251)">
@@ -120,6 +127,7 @@ export const CatchIcon: FC<Props> = ({
   color = 'var(--textColor)',
   className,
   onMouseEnter,
+  onMouseLeave
 }) => {
   return (
     <svg
@@ -130,6 +138,7 @@ export const CatchIcon: FC<Props> = ({
       viewBox="0 0 24 24"
       fill="none"
       onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <g clipPath="url(#clip0_4188_3250)">
         <g clipPath="url(#clip1_4188_3250)">

--- a/src/libs/types/rust.ts
+++ b/src/libs/types/rust.ts
@@ -13,6 +13,7 @@ export type UserSmall = {
   mentions: number | null;
   ranked_maps: number;
   username: string;
+  previous_usernames: string[];
 };
 
 export type User = UserSmall & {

--- a/src/services/influence/addInfluence.ts
+++ b/src/services/influence/addInfluence.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
 export type AddInfluenceRequest = {
-  userId: string | number;
+  user_id: string | number;
   influence_type?: number;
   description?: string;
   beatmaps?: number[];
@@ -53,10 +53,10 @@ export const useAddInfluenceMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['leaderboards'] });
       // TODO: Change this to update current user influences
       queryClient.invalidateQueries({
-        queryKey: ['userBio', variables.userId.toString()],
+        queryKey: ['userBio', variables.user_id.toString()],
       });
       queryClient.invalidateQueries({
-        queryKey: ['mentions', variables.userId.toString()],
+        queryKey: ['mentions', variables.user_id.toString()],
       });
     },
     onError: () =>


### PR DESCRIPTION
Directly passing profile user and influence user names for suggestions. Also fixing difficulty icon tooltip.
(I added `previous_users` to `UserSmall` in backend so that we can pass it without needing an extra request.) 

Also disabling public leaderboard user profile prefetch. 

Also renaming `userId` to `user_id` in influence add request body to keep it consistent along other types. If you prefer camelCase, I can rename variables both in frontend and backend.