### PR TITLE
Search and influence description debouncer fixes

### DIFF
--- a/src/components/Layout/Header/SearchBar/index.tsx
+++ b/src/components/Layout/Header/SearchBar/index.tsx
@@ -35,6 +35,7 @@ const SearchBar: FC<Props> = ({ className }) => {
     if (!query) {
       setResults([]);
       setShowResults(false);
+      return;
     }
 
     getSearchResults(query)
@@ -49,7 +50,9 @@ const SearchBar: FC<Props> = ({ className }) => {
       });
   }, []);
 
-  const debouncedSearch = AwesomeDebouncePromise(searchUser, 300);
+  // keeping the debounce time a little longer for search
+  // because it's 4 separate osu api requests for each query
+  const debouncedSearch = AwesomeDebouncePromise(searchUser, 600);
 
   const handleChange = (query: string) => {
     // TODO: Display loading indicator

--- a/src/components/SharedComponents/MapSearch/index.tsx
+++ b/src/components/SharedComponents/MapSearch/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 
 import type { BeatmapsetSmall } from '@libs/types/rust';
 import { searchMaps } from '@services/search';
@@ -39,9 +39,12 @@ export const AddMapModalContents: FC<{
       : '',
   );
 
-  const debouncedSearch = AwesomeDebouncePromise((query: string) => {
-    searchMaps(query + getFiltersQuery()).then(setMapResults);
-  }, 300);
+  const debouncedSearch = useCallback(
+    AwesomeDebouncePromise((query: string) => {
+      searchMaps(query + getFiltersQuery()).then(setMapResults);
+    }, 400),
+    [getFiltersQuery]
+  );
 
   const toggleMap = (id: number) => {
     setSelectedMaps((old) => {


### PR DESCRIPTION
Influence description edit: 
This was straight up annoying. Debouncer was working but since every time the border changed and the component rerendered, the debouncer was resetting. causing constant requests. On top of that, once the request was submitted, the textbox was disabled for just one frame (I think), so that it would just kick you out of it and since you were typing, browser shortcuts take over and you would do something unwanted. Also the database activity logs are full of people trying and failing to edit descriptions. 

Map search:
This was straight up not working. It used to send a request for every key stroke. I think this was caused because `setSearchInput` was causing rerender. 

User search:
I increased the debounce time. It's really costly in terms of osu api requests (one for search, 3 more for user data) I also added return to query function to avoid one extra request when the input text field is empty.